### PR TITLE
Fix improperly export UUIDs

### DIFF
--- a/src/coder/crockford32.js
+++ b/src/coder/crockford32.js
@@ -107,7 +107,6 @@ class Crockford32Coder extends BaseCoder {
 		for (let idx = 0, end = quintets.length; idx < end; ++idx) {
 			encoding += _quintetToChar(quintets[idx]);
 		}
-
 		return encoding;
 	}
 }

--- a/src/coder/uuid.js
+++ b/src/coder/uuid.js
@@ -55,7 +55,7 @@ class UuidCoder extends BaseCoder {
 
 	encodeTrusted(bytes) {
 		let idx = -1;
-		return (''
+		const encoding = (''
 			+ BYTE_TO_HEX[bytes[++idx]] + BYTE_TO_HEX[bytes[++idx]]
 			+ BYTE_TO_HEX[bytes[++idx]] + BYTE_TO_HEX[bytes[++idx]]
 			+ '-'
@@ -69,6 +69,7 @@ class UuidCoder extends BaseCoder {
 			+ BYTE_TO_HEX[bytes[++idx]] + BYTE_TO_HEX[bytes[++idx]]
 			+ BYTE_TO_HEX[bytes[++idx]] + BYTE_TO_HEX[bytes[++idx]]
 		);
+		return encoding;
 	}
 }
 

--- a/src/factory/id.js
+++ b/src/factory/id.js
@@ -10,8 +10,8 @@ class IdFactory {
 		canonical_coder,
 		raw_coder,
 	} = {}) {
-		const factory = this;
 		this[_id] = class extends id {
+			static get name() { return id.name; }
 			static get [Symbol.species]() { return id; }
 			get [Symbol.toStringTag]() { return `${id.name} ${this.toRaw()}`; }
 			toCanonical() { return canonical_coder.encodeTrusted(this.bytes); }

--- a/src/id/base.js
+++ b/src/id/base.js
@@ -22,8 +22,8 @@ class BaseId {
 	}
 
 	get [Symbol.toStringTag]() {
-    return this.constructor.name;
-  }
+		return this.constructor.name;
+	}
 
 	// Comparators
 


### PR DESCRIPTION
- was relying on a possible bug where anonymous classes inherited static name
from parent class.  anonymous classes are supposed to have an empty static name.
fixed by overriding static class name.
- also minor formatting changes