### PR TITLE
Explicitly use class name to fix issues with minifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,11 +39,26 @@ const namespace = {
 		canonical_coder: UuidCoder,
 		raw_coder: HexCoder,
 	}),
+	Uuid1: new IdFactory({
+		id: Uuid1,
+		canonical_coder: UuidCoder,
+		raw_coder: HexCoder,
+	}),
+	Uuid4: new IdFactory({
+		id: Uuid4,
+		canonical_coder: UuidCoder,
+		raw_coder: HexCoder,
+	}),
+	Uuid6: new IdFactory({
+		id: Uuid6,
+		canonical_coder: UuidCoder,
+		raw_coder: HexCoder,
+	}),
+	UuidNil: new IdFactory({
+		id: UuidNil,
+		canonical_coder: UuidCoder,
+		raw_coder: HexCoder,
+	}),
 };
-
-namespace.Uuid.versioned_ids.reduce(
-	(ns, uuid) => Object.assign(ns, {[uuid.name]: uuid}),
-	namespace
-);
 
 module.exports = namespace;


### PR DESCRIPTION
Common use of minifiers that do not preserve function/class name like esbuild/terser, require explicitly setting namespace 
UUID{0,1,4,6} entries to eliminate the issue of incorrect library API in bundled and minified applications. 